### PR TITLE
Fix qmake call (qt parameter no longer exists)

### DIFF
--- a/host-linux/GNUmakefile
+++ b/host-linux/GNUmakefile
@@ -22,7 +22,7 @@ endif
 include ../VERSION.mk
 
 all:
-	qmake -qt=5 VERSION=$(VERSIONEX)
+	qmake VERSION=$(VERSIONEX)
 	make -f Makefile
 
 clean:


### PR DESCRIPTION
`qt` parameter for qmake is no longer available after Qt 5.7.0 and it gives an error on make:
```
make `uname`
make[1]: Entering directory '/home/firat/Downloads/chrome-token-signing'
make -C host-linux
make[2]: Entering directory '/home/firat/Downloads/chrome-token-signing/host-linux'
qmake -qt=5 VERSION=1.0.3.0
***Unknown option -qt=5
```