### PR TITLE
make buildable on Debian Testing & Unstable

### DIFF
--- a/debian/chrome-token-signing.postinst
+++ b/debian/chrome-token-signing.postinst
@@ -1,4 +1,9 @@
 #!/bin/bash
 set -e
+
 mkdir -p /etc/opt/chrome/native-messaging-hosts
-ln -sf /usr/share/chrome-token-signing/ee.ria.esteid.json /etc/opt/chrome/native-messaging-hosts/ee.ria.esteid.json
+
+ln -sf /usr/share/chrome-token-signing/ee.ria.esteid.json \
+	/etc/opt/chrome/native-messaging-hosts/ee.ria.esteid.json
+
+#DEBHELPER#

--- a/debian/chrome-token-signing.postrm
+++ b/debian/chrome-token-signing.postrm
@@ -1,4 +1,9 @@
 #!/bin/bash
+
 set -e
+
 rm -f /etc/opt/chrome/native-messaging-hosts/ee.ria.esteid.json
+
 rmdir -p --ignore-fail-on-non-empty /etc/opt/chrome/native-messaging-hosts
+
+#DEBHELPER#

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,12 @@ Maintainer: RIA <info@ria.ee>
 Build-Depends:
  libssl-dev,
  qtbase5-dev,
- debhelper (>= 7)
+ debhelper (>= 7),
+ pkg-config,
+ libpcsclite-dev,
+ python,
+ xvfb,
+ xauth
 Standards-Version: 3.9.5
 Homepage: https://github.com/open-eid/chrome-token-signing
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export QT_SELECT=5
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,4 @@
+version=3
+opts="filenamemangle=s/.+\/v?(\d\S+)\.tar\.gz/chrome-token-signing-$1\.tar\.gz/,\
+  uversionmangle=s/(\d)[_\.\-\+]?((RC|rc|pre|dev|beta|alpha)\d*)$/$1~$2/" \
+  https://github.com/open-eid/chrome-token-signing/tags .*/v(\d\S+)\.tar\.gz


### PR DESCRIPTION
Some build dependencies were missing.

Note:

> dpkg-shlibdeps: warning: package could avoid a useless dependency if debian/chrome-token-signing/usr/bin/chrome-token-signing was not linked against libssl.so.1.0.0 (it uses none of the library's symbols)
> dpkg-shlibdeps: warning: package could avoid a useless dependency if debian/chrome-token-signing/usr/bin/chrome-token-signing was not linked against libGL.so.1 (it uses none of the library's symbols)
