### PR TITLE
Implement signing with ECDSA token

### DIFF
--- a/host-windows/NativeCertificateSelector.cpp
+++ b/host-windows/NativeCertificateSelector.cpp
@@ -33,7 +33,7 @@ vector<unsigned char> NativeCertificateSelector::getCert(bool forSigning) const 
 	while (cert = CertEnumCertificatesInStore(sys, cert)) {
 		if (!isValid(cert, forSigning))
 			continue;
-		DWORD flags = CRYPT_ACQUIRE_CACHE_FLAG | CRYPT_ACQUIRE_COMPARE_KEY_FLAG | CRYPT_ACQUIRE_SILENT_FLAG;
+		DWORD flags = CRYPT_ACQUIRE_CACHE_FLAG | CRYPT_ACQUIRE_COMPARE_KEY_FLAG | CRYPT_ACQUIRE_SILENT_FLAG | CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG;
 		NCRYPT_KEY_HANDLE key = 0;
 		DWORD spec = 0;
 		BOOL freeKey = FALSE;

--- a/host-windows/NativeSigner.h
+++ b/host-windows/NativeSigner.h
@@ -20,8 +20,8 @@
 
 #include "Signer.h"
 
-class CngCapiSigner : public Signer {
+class NativeSigner : public Signer {
 public:
-	CngCapiSigner(const std::string &certInHex) : Signer(certInHex){}
+	NativeSigner(const std::vector<unsigned char> &cert) : Signer(cert) {}
 	std::vector<unsigned char> sign(const std::vector<unsigned char> &digest) override;
 };

--- a/host-windows/Pkcs11Signer.h
+++ b/host-windows/Pkcs11Signer.h
@@ -19,11 +19,10 @@
 #pragma once
 
 #include "Signer.h"
-#include "PKCS11CardManager.h"
 
 class Pkcs11Signer : public Signer {
 public:
-	Pkcs11Signer(const std::string &pkcs11ModulePath, const std::string &certInHex);
+	Pkcs11Signer(const std::string &pkcs11ModulePath, const std::vector<unsigned char> &cert);
 	std::vector<unsigned char> sign(const std::vector<unsigned char> &digest) override;
 private:
 	int pinTriesLeft;

--- a/host-windows/RequestHandler.cpp
+++ b/host-windows/RequestHandler.cpp
@@ -136,13 +136,14 @@ void RequestHandler::handleSignRequest() {
 		_log("Hash length %i is invalid", hash.size());
 		throw InvalidHashException();
 	}
-	unique_ptr<Signer> signer(Signer::createSigner(jsonRequest.get<string>("cert")));
+	string certInHex = jsonRequest.get<string>("cert");
+	unique_ptr<Signer> signer(Signer::createSigner(BinaryUtils::hex2bin(certInHex)));
 	
 	if (!signer->showInfo(jsonRequest.get<string>("info", string())))
 		throw UserCancelledException();
 
-	_log("signing hash: %s, with certId: %s", hash.c_str(), signer->getCertInHex().c_str());
-	validateContext(signer->getCertInHex());
+	_log("signing hash: %s, with certId: %s", hash.c_str(), certInHex.c_str());
+	validateContext(certInHex);
 	string signature = BinaryUtils::bin2hex(signer->sign(digest));
 	_log("Sign result: %s", signature.c_str());
 	jsonResponse << "signature" << signature;

--- a/host-windows/Signer.cpp
+++ b/host-windows/Signer.cpp
@@ -18,18 +18,20 @@
 
 #include "Signer.h"
 #include "HostExceptions.h"
-#include "CngCapiSigner.h"
+#include "NativeSigner.h"
 #include "Pkcs11Signer.h"
 #include "PKCS11Path.h"
 
+#include <Windows.h>
+
 using namespace std;
 
-Signer * Signer::createSigner(const string &cert){
+Signer * Signer::createSigner(const vector<unsigned char> &cert){
 	PKCS11Path::Params p11 = PKCS11Path::getPkcs11ModulePath();
 	if (!p11.path.empty()) {
 		return new Pkcs11Signer(p11.path, cert);
 	}
-	return new CngCapiSigner(cert);
+	return new NativeSigner(cert);
 }
 
 bool Signer::showInfo(const string &msg)

--- a/host-windows/Signer.h
+++ b/host-windows/Signer.h
@@ -31,14 +31,12 @@ class Signer {
 public:
 	virtual ~Signer() = default;
 
-	static Signer* createSigner(const std::string &cert);
-	std::string getCertInHex() const { return certInHex; }
+	static Signer* createSigner(const std::vector<unsigned char> &cert);
 	bool showInfo(const std::string &msg);
 	virtual std::vector<unsigned char> sign(const std::vector<unsigned char> &digest) = 0;
 
 protected:
-	Signer(const std::string &_certInHex): certInHex(_certInHex) {}
+	Signer(const std::vector<unsigned char> &_cert) : cert(_cert) {}
 
-private:
-	std::string certInHex;
+	std::vector<unsigned char> cert;
 };

--- a/host-windows/host-windows.vcxproj
+++ b/host-windows/host-windows.vcxproj
@@ -99,11 +99,11 @@
     <ClInclude Include="..\host-shared\PKCS11Path.h" />
     <ClInclude Include="..\host-shared\VersionInfo.h" />
     <ClInclude Include="CertificateSelector.h" />
-    <ClInclude Include="CngCapiSigner.h" />
     <ClInclude Include="ContextMaintainer.h" />
     <ClInclude Include="HostExceptions.h" />
     <ClInclude Include="IOCommunicator.h" />
     <ClInclude Include="NativeCertificateSelector.h" />
+    <ClInclude Include="NativeSigner.h" />
     <ClInclude Include="PinDialog.h" />
     <ClInclude Include="PKCS11CertificateSelector.h" />
     <ClInclude Include="Pkcs11Signer.h" />
@@ -123,11 +123,11 @@
     <ClCompile Include="chrome-token-signing.cpp" />
     <ClCompile Include="IOCommunicator.cpp" />
     <ClCompile Include="NativeCertificateSelector.cpp" />
+    <ClCompile Include="NativeSigner.cpp" />
     <ClCompile Include="PinDialog.cpp" />
     <ClCompile Include="PKCS11CertificateSelector.cpp" />
     <ClCompile Include="Pkcs11Signer.cpp" />
     <ClCompile Include="RequestHandler.cpp" />
-    <ClCompile Include="CngCapiSigner.cpp" />
     <ClCompile Include="Signer.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/host-windows/host-windows.vcxproj.filters
+++ b/host-windows/host-windows.vcxproj.filters
@@ -48,9 +48,6 @@
     <ClInclude Include="Pkcs11Signer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="CngCapiSigner.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="PinDialog.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -64,6 +61,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="NativeCertificateSelector.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="NativeSigner.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="PKCS11CertificateSelector.h">
@@ -101,13 +101,13 @@
     <ClCompile Include="Pkcs11Signer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="CngCapiSigner.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="PinDialog.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="NativeCertificateSelector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="NativeSigner.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="PKCS11CertificateSelector.cpp">


### PR DESCRIPTION
- Rename CngCapiSigner to NativeSigner to match NativeCertificateSelector
- Fix certificate selection with NCrypt backend only
- Ask from crypto backend correct signature length
- use decode HEX certificate only once

Signed-off-by: Raul Metsma <raul@metsma.ee>