### PR TITLE
Added qt5-default to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
    1.1 Ubuntu
 
-        sudo apt-get install qtbase5-dev libssl-dev libpcsclite-dev
+        sudo apt-get install qtbase5-dev libssl-dev libpcsclite-dev qt5-default
 
    1.2 Windows
 


### PR DESCRIPTION
Without it, `make` gives the error `qmake: could not find a Qt installation of ''`