### PR TITLE
Remove legacy exception, OSX 10.9 is not supported

### DIFF
--- a/host-osx/chrome-token-signing.entitlements
+++ b/host-osx/chrome-token-signing.entitlements
@@ -6,7 +6,5 @@
 	<true/>
 	<key>com.apple.security.smartcard</key>
 	<true/>
-	<key>com.apple.security.temporary-exception.files.absolute-path.read-only</key>
-	<string>/private/var/run/pcscd.pub</string>
 </dict>
 </plist>


### PR DESCRIPTION
Signed-off-by: Raul Metsma <raul@metsma.ee>