### PR TITLE
Fix sign comparison warning

### DIFF
--- a/host-linux/Signer.h
+++ b/host-linux/Signer.h
@@ -210,7 +210,7 @@ private:
             pin->setValidator(new QRegExpValidator(QRegExp(QString("\\d{%1,12}").arg(minPinLen)), pin));
             pin->setMaxLength(12);
             connect(pin, &QLineEdit::textEdited, [=](const QString &text){
-                ok->setEnabled((unsigned long)text.size() >= minPinLen);
+                ok->setEnabled(text.size() >= int(minPinLen));
             });
 
             layout->addWidget(pin);

--- a/host-linux/Signer.h
+++ b/host-linux/Signer.h
@@ -210,7 +210,7 @@ private:
             pin->setValidator(new QRegExpValidator(QRegExp(QString("\\d{%1,12}").arg(minPinLen)), pin));
             pin->setMaxLength(12);
             connect(pin, &QLineEdit::textEdited, [=](const QString &text){
-                ok->setEnabled(text.size() >= minPinLen);
+                ok->setEnabled((unsigned long)text.size() >= minPinLen);
             });
 
             layout->addWidget(pin);


### PR DESCRIPTION
Hey, this fixes the sign comparison warning when compiling chrome-host.cpp :

```
Signer.h: In lambda function:
Signer.h:213:44: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
                 ok->setEnabled(text.size() >= minPinLen);
```