### PR TITLE
Add "messages" attribute to uniquely describe each error case

### DIFF
--- a/host-osx/CertificateSelection.mm
+++ b/host-osx/CertificateSelection.mm
@@ -147,7 +147,7 @@ static NSTouchBarItemIdentifier touchBarItemSegmentId = @"ee.ria.chrome-token-si
     try {
         CertificateSelection *dialog = [[CertificateSelection alloc] init];
         if (!dialog) {
-            return @{@"result": @"technical_error"};
+            return @{@"result": @"technical_error", @"message": @"Dialog could not be initialised."};
         }
         if (dialog->certificates.count == 0) {
             return @{@"result": @"no_certificates"};
@@ -161,7 +161,7 @@ static NSTouchBarItemIdentifier touchBarItemSegmentId = @"ee.ria.chrome-token-si
         return @{@"cert": dialog->certificates[dialog->certificateSelection.selectedRow][@"cert"]};
     } catch(const BaseException &e) {
         _log("Exception: %s", e.what());
-        return @{@"result": @(e.getErrorCode().c_str())};
+        return @{@"result": @(e.getErrorCode().c_str()), @"message": @(e.runtime_error::what())};
     }
 }
 

--- a/host-osx/chrome-host.mm
+++ b/host-osx/chrome-host.mm
@@ -80,8 +80,9 @@ int main(int argc, const char * argv[]) {
                     _log("Message size: %u", size);
                 }
                 if (size > 8*1024) {
-                    _log("Size (%u) exceeds allowed size", size, 8*1024);
-                    write(@{@"result": @"invalid_argument"}, nil);
+                    NSString *message = [NSString stringWithFormat:@"Size (%u) exceeds allowed size %u.", size, 8*1024];
+                    _log(message.UTF8String);
+                    write(@{@"result": @"invalid_argument",@"message": message}, nil);
                     return exit(1);
                 }
                 if (data.length < pos + size) {
@@ -99,19 +100,30 @@ int main(int argc, const char * argv[]) {
                 NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:json options:0 error:&error];
                 NSDictionary *result;
                 if (dict == nil || error) {
-                    write(@{@"result": @"invalid_argument"}, nil);
+                    write(@{@"result": @"invalid_argument",@"message": error != nil ? error.localizedDescription : nil}, nil);
                     return exit(1);
                 }
 
-                if(!dict[@"nonce"] || !dict[@"type"] || !dict[@"origin"]) {
-                    write(@{@"result": @"invalid_argument"}, dict[@"nonce"]);
+                if(!dict[@"nonce"]) {
+                    write(@{@"result": @"invalid_argument",@"message": @"'nonce' attribute is missing."}, dict[@"nonce"]);
+                    return exit(1);
+                }
+
+                if(!dict[@"type"]) {
+                    write(@{@"result": @"invalid_argument",@"message": @"'type' attribute is missing."}, dict[@"nonce"]);
+                    return exit(1);
+                }
+
+                if(!dict[@"origin"]) {
+                    write(@{@"result": @"invalid_argument",@"message": @"'origin' attribute is missing."}, dict[@"nonce"]);
                     return exit(1);
                 }
 
                 if (!origin) {
                     origin = dict[@"origin"];
                 } else if (![origin isEqualToString:dict[@"origin"]]) {
-                    write(@{@"result": @"invalid_argument"}, nil);
+                    NSString *message = [NSString stringWithFormat:@"Origin '%@' is not equal to '%@'.", origin, dict[@"origin"]];
+                    write(@{@"result": @"invalid_argument",@"message": message}, nil);
                     return exit(1);
                 }
 
@@ -123,21 +135,27 @@ int main(int argc, const char * argv[]) {
                     result = @{@"version": version};
                 }
                 else if ([dict[@"origin"] compare:@"https" options:NSCaseInsensitiveSearch range:NSMakeRange(0, 5)]) {
-                    result = @{@"result": @"not_allowed"};
+                    NSString *message = [NSString stringWithFormat:@"Origin '%@' does not contain 'https'.", dict[@"origin"]];
+                    result = @{@"result": @"not_allowed",@"message": message};
                 }
                 else if([dict[@"type"] isEqualToString:@"CERT"]) {
                     if ([@"AUTH" isEqualToString:dict[@"filter"]]) {
-                        result = @{@"result": @"invalid_argument"};
+                        result = @{@"result": @"invalid_argument",@"message": @"Filter cannot be 'AUTH' when type is 'CERT'."};
                     } else {
                         result = [CertificateSelection show];
                         cert = (NSString*)result[@"cert"];
                     }
                 }
                 else if ([dict[@"type"] isEqualToString:@"SIGN"]) {
-                    result = [PINPanel show:dict cert:cert];
+                    if (cert == nil) {
+                        result = @{@"result": @"invalid_argument", @"message": @"Type 'CERT' must be called before type 'SIGN'."};
+                    } else {
+                        result = [PINPanel show:dict cert:cert];
+                    }
                 }
                 else {
-                    result = @{@"result": @"invalid_argument"};
+                    NSString *message = [NSString stringWithFormat:@"Type '%@' is not recognised.", dict[@"type"]];
+                    result = @{@"result": @"invalid_argument", @"message": message};
                 }
 
                 write(result, dict[@"nonce"]);


### PR DESCRIPTION
Add "messages" attribute to uniquely describe each error case, aligned with the
windows behaviour.

Fix a segfault when the SIGN step is attempted before successfully completing
the CERT step.