### PR TITLE
improved page script csp solution for #158

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -45,83 +45,6 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     window.postMessage(request, '*');
 });
 
-var pageScript = function() {
-    // Promises
-    var _eid_promises = {};
-    // Turn the incoming message from extension
-    // into pending Promise resolving
-    window.addEventListener("message", function(event) {
-        if (event.source !== window) return;
-        if (event.data.src && (event.data.src === "background.js")) {
-            console.log("Page received: ");
-            console.log(event.data);
-            // Get the promise
-            if (event.data.nonce) {
-                var p = _eid_promises[event.data.nonce];
-                // resolve
-                if (event.data.result === "ok") {
-                    if (event.data.signature !== undefined) {
-                        p.resolve({hex: event.data.signature});
-                    } else if (event.data.version !== undefined) {
-                        p.resolve(event.data.extension + "/" + event.data.version);
-                    } else if (event.data.cert !== undefined) {
-                        p.resolve({hex: event.data.cert});
-                    } else {
-                        console.log("No idea how to handle message");
-                        console.log(event.data);
-                    }
-                } else {
-                    // reject
-                    p.reject(new Error(event.data.result));
-                }
-                delete _eid_promises[event.data.nonce];
-            } else {
-                console.log("No nonce in event msg");
-            }
-        }
-    }, false);
-
-    window.TokenSigning = function() {
-        function nonce() {
-            var val = "";
-            var hex = "abcdefghijklmnopqrstuvwxyz0123456789";
-            for (var i = 0; i < 16; i++) val += hex.charAt(Math.floor(Math.random() * hex.length));
-            return val;
-        }
-
-        function messagePromise(msg) {
-            return new Promise(function(resolve, reject) {
-                // amend with necessary metadata
-                msg["nonce"] = nonce();
-                msg["src"] = "page.js";
-                // send message
-                window.postMessage(msg, "*");
-                // and store promise callbacks
-                _eid_promises[msg.nonce] = {
-                    resolve: resolve,
-                    reject: reject
-                };
-            });
-        }
-        this.getCertificate = function(options) {
-            var msg = {type: "CERT", lang: options.lang, filter: options.filter};
-            console.log("getCertificate()");
-            return messagePromise(msg);
-        };
-        this.sign = function(cert, hash, options) {
-            var msg = {type: "SIGN", cert: cert.hex, hash: hash.hex, hashtype: hash.type, lang: options.lang, info: options.info};
-            console.log("sign()");
-            return messagePromise(msg);
-        };
-        this.getVersion = function() {
-            console.log("getVersion()");
-            return messagePromise({
-                type: "VERSION"
-            });
-        };
-    };
-};
-
 /**
  * Check the page for an existing TokenSigning page script.
  * The script will be injected to the DOM of every page, which doesn't already have the script.
@@ -137,7 +60,7 @@ if (!document.querySelector("script[data-name='TokenSigning']")) {
     var s = document.createElement("script");
     s.type = "text/javascript";
     s.dataset.name = "TokenSigning";
-    s.innerHTML = "(" + pageScript + ")();";
+    s.src = chrome.runtime.getURL('/page.js');
 
     (document.head || document.documentElement).appendChild(s);
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -15,6 +15,9 @@
         "run_at": "document_end",
         "all_frames": true
     }],
+    "web_accessible_resources": [
+        "page.js"
+    ],
     "background": {
         "scripts": ["background.js"]
     },


### PR DESCRIPTION
Issue https://github.com/open-eid/chrome-token-signing/issues/158 was resolved by a workaround: have each page that uses token signing include the page script manually. This has some drawbacks: 

- the script may not match what's included in the installed version of chrome-token-signing
- it breaks backend probing in hwcrypto.js - it now always detects that chrome-token-signing is installed

This PR proposes a better solution: inject the script tag but link directly to the page.js inside the extension. The result is something like this:

```
<script type="text/javascript" data-name="TokenSigning" src="chrome-extension://ckjefchnfjhjfedoccjbhjpbncimppeg/page.js"></script>
```

This is better because it's no longer a inline script (does not need unsafe-inline permissions), so it's possible to use a more specific exception in the CSP. But even that doesn't seem to be necessary: the extension urls seem to bypass CSP automatically. The following CSP works without any changes: `Content-Security-Policy: default-src 'self';`

See also https://stackoverflow.com/a/9517879